### PR TITLE
feat: True Chitra ayanamsa dasha integration

### DIFF
--- a/src/app/client/[id]/comparison/page.tsx
+++ b/src/app/client/[id]/comparison/page.tsx
@@ -77,7 +77,10 @@ export default function ClientComparisonPage() {
                         options={[
                             { value: "Lahiri", label: "Lahiri (Chitra Paksha)" },
                             { value: "Raman", label: "BV Raman" },
-                            { value: "KP", label: "Krishnamurti Paddhati" }
+                            { value: "KP", label: "Krishnamurti Paddhati" },
+                            { value: "Yukteswar", label: "Sri Yukteswar" },
+                            { value: "Bhasin", label: "Bhasin" },
+                            { value: "TrueChitra", label: "True Chitra" }
                         ]}
                     />
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,7 +5,7 @@ import { Save, Settings2 } from "lucide-react";
 import Button from "@/components/ui/Button";
 import { useToast } from "@/context/ToastContext";
 
-type Ayanamsa = "lahiri" | "raman" | "kp";
+type Ayanamsa = "lahiri" | "raman" | "kp" | "yukteswar" | "bhasin" | "true_chitra";
 type ChartStyle = "north_indian" | "south_indian" | "east_indian";
 
 const SETTINGS_KEY = "grahvani:chart-preferences";
@@ -96,6 +96,9 @@ export default function SettingsPage() {
                         { value: "lahiri", label: "Lahiri (Chitrapaksha)", desc: "Most common in India" },
                         { value: "raman", label: "Raman", desc: "B.V. Raman's system" },
                         { value: "kp", label: "KP (Krishnamurti)", desc: "Krishnamurti Paddhati" },
+                        { value: "yukteswar", label: "Sri Yukteswar", desc: "Galactic Center based precision" },
+                        { value: "bhasin", label: "Bhasin", desc: "J.N. Bhasin ayanamsa system" },
+                        { value: "true_chitra", label: "True Chitra", desc: "True Chitra ayanamsa — dasha-only system" },
                     ] as const).map((option) => (
                         <button
                             key={option.value}

--- a/src/app/vedic-astrology/customize/AyanamsaSelect.tsx
+++ b/src/app/vedic-astrology/customize/AyanamsaSelect.tsx
@@ -182,10 +182,11 @@ export function AyanamsaSelect({
                     style={{
                         background: `linear-gradient(90deg, 
                             ${AYANAMSA_OPTIONS[0].color} 0%, 
-                            ${AYANAMSA_OPTIONS[1].color} 25%, 
-                            ${AYANAMSA_OPTIONS[2].color} 50%, 
-                            ${AYANAMSA_OPTIONS[3].color} 75%, 
-                            ${AYANAMSA_OPTIONS[4].color} 100%)`
+                            ${AYANAMSA_OPTIONS[1].color} 20%, 
+                            ${AYANAMSA_OPTIONS[2].color} 40%, 
+                            ${AYANAMSA_OPTIONS[3].color} 60%, 
+                            ${AYANAMSA_OPTIONS[4].color} 80%,
+                            ${AYANAMSA_OPTIONS[5].color} 100%)`
                     }}
                 />
             </div>

--- a/src/app/vedic-astrology/customize/ayana-types.ts
+++ b/src/app/vedic-astrology/customize/ayana-types.ts
@@ -12,7 +12,7 @@ import {
 /**
  * Supported Ayanamsa Systems for the Customize Page
  */
-export const AYANAMSA_SYSTEMS = ['Lahiri', 'KP', 'Raman', 'Yukteswar', 'Bhasin'] as const;
+export const AYANAMSA_SYSTEMS = ['Lahiri', 'KP', 'Raman', 'Yukteswar', 'Bhasin', 'TrueChitra'] as const;
 export type AyanamsaSystem = typeof AYANAMSA_SYSTEMS[number];
 
 /**
@@ -24,7 +24,8 @@ export const AYANAMSA_OPTIONS: { value: AyanamsaSystem; label: string; color: st
     { value: 'KP', label: 'KP', color: '#E6C97A' },
     { value: 'Raman', label: 'Raman', color: '#D17C4D' },
     { value: 'Yukteswar', label: 'Yukteswar', color: '#7C4DFF' },
-    { value: 'Bhasin', label: 'Bhasin', color: '#4CAF50' }
+    { value: 'Bhasin', label: 'Bhasin', color: '#4CAF50' },
+    { value: 'TrueChitra', label: 'True Chitra', color: '#9C27B0' }
 ];
 
 export interface WidgetRef {
@@ -291,6 +292,23 @@ export const AYANAMSA_HIERARCHY: AyanamsaOption[] = [
                 ]
             }
         ]
+    },
+    {
+        value: 'TrueChitra',
+        label: 'True Chitra',
+        description: 'True Chitra ayanamsa — specialized dasha-only system with 12 dasha variants.',
+        categories: [
+            {
+                id: 'cat-true-chitra',
+                name: 'True Chitra Dasha Systems',
+                widgets: [
+                    { id: 'prana' }, { id: 'ashtottari' }, { id: 'tribhagi' }, { id: 'tribhagi_40' },
+                    { id: 'shodashottari' }, { id: 'dwadashottari' }, { id: 'dwisaptati' },
+                    { id: 'shastihayani' }, { id: 'shattrimshatsama' }, { id: 'panchottari' },
+                    { id: 'satabdika' }, { id: 'chaturshitisama' }
+                ]
+            }
+        ]
     }
 ];
 
@@ -429,6 +447,22 @@ export const AYANAMSA_CONFIGS: Record<AyanamsaSystem, AyanamsaConfig> = {
             'cat-dashas',
             'cat-chakra'
         ]
+    },
+    /**
+     * True Chitra System
+     * Supports:
+     * - Dasha Systems ONLY (no natal/divisional charts)
+     * - 12 specialized dasha variants under True Chitra ayanamsa
+     */
+    TrueChitra: {
+        title: 'True Chitra Workbench',
+        subtitle: 'True Chitra Ayanamsa Dasha Analysis',
+        themeColor: '#9C27B0',
+        pillLabel: 'True Chitra',
+        allowedCategoryIds: [
+            'all',
+            'cat-true-chitra'
+        ]
     }
 };
 
@@ -491,6 +525,13 @@ export const WORKBENCH_CATEGORIES: WorkbenchCategory[] = [
         description: 'Triple-ring planetary alignment',
         icon: IterationCcw,
         allowedAyanamsas: ['Lahiri', 'KP', 'Raman', 'Yukteswar', 'Bhasin']
+    },
+    {
+        id: 'cat-true-chitra',
+        name: 'True Chitra Dasha',
+        description: 'True Chitra ayanamsa dasha systems',
+        icon: History,
+        allowedAyanamsas: ['TrueChitra']
     }
 ];
 

--- a/src/app/vedic-astrology/dashas/page.tsx
+++ b/src/app/vedic-astrology/dashas/page.tsx
@@ -82,11 +82,15 @@ export default function VedicDashasPage() {
     const { ayanamsa, chartStyle, recentClientIds } = useAstrologerStore();
     const settings = { ayanamsa, chartStyle, recentClientIds };
 
-    // D1 Chart Logic for Sidebar
-    const activeSystem = settings.ayanamsa.toLowerCase();
+    // Normalize ayanamsa for API calls: TrueChitra -> true_chitra
+    const apiAyanamsa = settings.ayanamsa === 'TrueChitra' ? 'true_chitra' : settings.ayanamsa.toLowerCase();
+    const isTrueChitra = settings.ayanamsa === 'TrueChitra';
+
+    // D1 Chart Logic for Sidebar (only for non-TrueChitra systems)
+    const activeSystem = apiAyanamsa;
     const d1Chart = React.useMemo(() => {
-        return processedCharts[`D1_${activeSystem}`];
-    }, [activeSystem, processedCharts]);
+        return isTrueChitra ? null : processedCharts[`D1_${activeSystem}`];
+    }, [activeSystem, processedCharts, isTrueChitra]);
 
     const { planets: displayPlanets, ascendant: ascendantSign } = parseChartData(d1Chart?.chartData);
 
@@ -111,37 +115,50 @@ export default function VedicDashasPage() {
     const { data: treeResponse, isLoading: treeLoading, error: treeError } = useDasha(
         clientDetails?.id || '',
         'mahadasha',
-        settings.ayanamsa.toLowerCase()
+        apiAyanamsa
     );
 
     const { data: otherData, isLoading: otherLoading, error: otherError } = useOtherDasha(
         clientDetails?.id || '',
         selectedDashaType,
-        settings.ayanamsa.toLowerCase()
+        apiAyanamsa
     );
 
     const isVimshottari = selectedDashaType === 'vimshottari';
     const isLoading = isVimshottari ? treeLoading : otherLoading;
 
-    // Derived flags for specialized views
-    const isTribhagi = selectedDashaType.includes('tribhagi');
+    // Dasha type flags (used for routing to specialized components & drill-down logic)
+    const isAshtottari = selectedDashaType === 'ashtottari';
+    const isChara = selectedDashaType === 'chara';
+    const isTribhagi = selectedDashaType === 'tribhagi';
     const isShodashottari = selectedDashaType === 'shodashottari';
     const isDwadashottari = selectedDashaType === 'dwadashottari';
-    const isPanchottari = selectedDashaType.includes('panchottari');
+    const isPanchottari = selectedDashaType === 'panchottari';
     const isChaturshitisama = selectedDashaType === 'chaturshitisama';
     const isSatabdika = selectedDashaType === 'satabdika';
     const isDwisaptati = selectedDashaType === 'dwisaptati';
-    const isAshtottari = selectedDashaType === 'ashtottari';
-    const isChara = selectedDashaType === 'chara';
-    // Fallback detection for Shastihayani via metadata condition
-    const hasShasthiMeta = Boolean(((otherData?.data?.mahadashas as Record<string, unknown> | undefined)?.meta as Record<string, unknown> | undefined)?.shastihayani_condition);
-    const isShasthihayani = selectedDashaType === 'shastihayani' || hasShasthiMeta;
-    const hasShattrimMeta = Boolean(((otherData?.data?.mahadashas as Record<string, unknown> | undefined)?.meta as Record<string, unknown> | undefined)?.shattrimshatsama_condition);
-    const isShattrimshatsama = selectedDashaType === 'shattrimshatsama' || hasShattrimMeta;
+    const isShasthihayani = selectedDashaType === 'shastihayani';
+    const isShattrimshatsama = selectedDashaType === 'shattrimshatsama';
 
-    const allowMathematicalDrillDown = isVimshottari && !isTribhagi && !isShodashottari && !isDwadashottari && !isPanchottari && !isChaturshitisama && !isSatabdika && !isDwisaptati && !isShasthihayani && !isShattrimshatsama && !isAshtottari;
+    // Compute max available levels from the processed tree
+    // This is dynamic — each dasha system returns different depths
+    const maxAvailableLevel = useMemo(() => {
+        if (!dashaTree || dashaTree.length === 0) return 0;
+        // Check first maha's children depth
+        const firstMaha = dashaTree[0];
+        let depth = 0;
+        let current = firstMaha;
+        while (current?.sublevel && current.sublevel.length > 0 && depth < 4) {
+            depth++;
+            current = current.sublevel[0];
+        }
+        return depth;
+    }, [dashaTree]);
 
-    // Effect: Reset to Vimshottari if Raman/KP is selected, unless KP is using Chara
+    // Show drill-down UI only if data has 2+ levels
+    const allowMathematicalDrillDown = maxAvailableLevel >= 1;
+
+    // Effect: Reset dasha type when ayanamsa changes
     useEffect(() => {
         if (settings.ayanamsa === 'Raman' && selectedDashaType !== 'vimshottari') {
             setSelectedDashaType('vimshottari');
@@ -150,6 +167,12 @@ export default function VedicDashasPage() {
             setDashaTree([]);
         } else if (settings.ayanamsa === 'KP' && selectedDashaType !== 'vimshottari') {
             setSelectedDashaType('vimshottari');
+            setCurrentLevel(0);
+            setSelectedPath([]);
+            setDashaTree([]);
+        } else if (settings.ayanamsa === 'TrueChitra' && selectedDashaType === 'vimshottari') {
+            // True Chitra has no vimshottari — default to first available dasha
+            setSelectedDashaType('ashtottari');
             setCurrentLevel(0);
             setSelectedPath([]);
             setDashaTree([]);
@@ -163,11 +186,9 @@ export default function VedicDashasPage() {
     useEffect(() => {
         const dashaData = isVimshottari ? treeResponse?.data : otherData?.data;
         if (dashaData) {
-            // Use the robust processor from utils
-            // HARD-LOCK: Specialized systems get maxLevel 1 (Antardasha), Vimshottari gets 4 (Prana)
-            // HARD-LOCK: Specialized systems get maxLevel 1 (Antardasha), Vimshottari gets 4 (Prana), Ashtottari gets 2 (Pratyantar)
-            const maxLevel = isVimshottari ? 4 : (isAshtottari ? 2 : (isTribhagi || isShodashottari || isDwadashottari || isPanchottari || isChaturshitisama || isSatabdika || isDwisaptati || isShasthihayani || isShattrimshatsama ? 1 : 4));
-            const processedTree = processDashaResponse(dashaData, maxLevel);
+            // Auto-detect depth from the API response — no hard-coded limits
+            // Each dasha system returns its own natural depth (2-5 levels)
+            const processedTree = processDashaResponse(dashaData);
 
             if (processedTree.length > 0) {
                 // Vimshottari has exactly 9 planetary lords per cycle - limit to one cycle
@@ -175,10 +196,6 @@ export default function VedicDashasPage() {
                 setDashaTree(finalTree);
 
                 // Real-time analysis of the current active sequence
-                // We can still use the raw response for this if findActiveDashaPath expects raw
-                // Or update findActiveDashaPath to handle processed notes.
-                // dasha-utils findActiveDashaPath handles raw. 
-                // Let's stick to that for the "Active Analysis" widget.
                 const analysis = findActiveDashaPath(dashaData);
                 setActiveAnalysis(analysis);
 
@@ -187,12 +204,11 @@ export default function VedicDashasPage() {
                 }
             }
         }
-    }, [treeResponse, otherData, isVimshottari, isTribhagi, isShodashottari, isDwadashottari, isPanchottari, isChaturshitisama, isSatabdika, isDwisaptati, isShasthihayani, isShattrimshatsama, isAshtottari]);
+    }, [treeResponse, otherData, isVimshottari]);
 
 
 
     // Derived Viewing Periods based on drill-down
-    // This allows traversing the full 5-level tree
     useEffect(() => {
         if ((!allowMathematicalDrillDown && !isAshtottari && currentLevel > 1) || (isAshtottari && currentLevel > 2)) {
             setCurrentLevel(0);
@@ -200,15 +216,11 @@ export default function VedicDashasPage() {
         }
 
         if (!allowMathematicalDrillDown || (isTribhagi && currentLevel >= 1) || (isShodashottari && currentLevel >= 1) || (isDwadashottari && currentLevel >= 1) || (isPanchottari && currentLevel >= 1) || (isChaturshitisama && currentLevel >= 1) || (isSatabdika && currentLevel >= 1) || (isDwisaptati && currentLevel >= 1) || (isAshtottari && currentLevel >= 2)) {
-            // Revert: If it's specialized and we are at Antardasha or deeper, don't allow further
             if ((isTribhagi || isShodashottari || isDwadashottari || isPanchottari || isChaturshitisama || isSatabdika || isDwisaptati) && currentLevel === 0) {
                 setViewingPeriods(dashaTree);
             } else if (!isTribhagi && !isShodashottari && !isDwadashottari && !isPanchottari && !isChaturshitisama && !isSatabdika && !isDwisaptati && !isAshtottari) {
                 setViewingPeriods(dashaTree);
             }
-            // For other systems, just show the root level (processed via standardizeDashaLevels previously)
-            // But now we rely on dashaTree being processed.
-            // Actually, the original logic for non-vimshottari was just showing root.
             if (!isVimshottari && !isTribhagi && !isShodashottari && !isDwadashottari && !isPanchottari && !isChaturshitisama && !isSatabdika && !isDwisaptati && !isAshtottari && !isChara) {
                 setViewingPeriods(dashaTree);
                 return;
@@ -216,17 +228,7 @@ export default function VedicDashasPage() {
         }
 
         let currentNodes = dashaTree;
-
-        // Traverse down the path
         for (const p of selectedPath) {
-            // p is the raw node in the old code, but let's see. 
-            // In handleDrillDown below, we should push the PLANET NAME or ID to path, 
-            // like the Demo does.
-            // Refactoring path to store IDs/Names is cleaner than storing objects.
-            // BUT, to minimize breaking changes, let's see what selectedPath stores.
-            // Currently it stores provided objects "raw".
-
-            // If selectedPath stores objects, we find the matching node in currentNodes
             const match = currentNodes.find(n => n.planet === (p.planet || p.lord));
             if (match && match.sublevel) {
                 currentNodes = match.sublevel;
@@ -235,10 +237,8 @@ export default function VedicDashasPage() {
                 break;
             }
         }
-
         setViewingPeriods(currentNodes);
-
-    }, [dashaTree, selectedPath, allowMathematicalDrillDown, isTribhagi, isShodashottari, isDwadashottari, isPanchottari, isChaturshitisama, isSatabdika, isDwisaptati, currentLevel, isAshtottari]);
+    }, [dashaTree, selectedPath, allowMathematicalDrillDown, isTribhagi, isShodashottari, isDwadashottari, isPanchottari, isChaturshitisama, isSatabdika, isDwisaptati, currentLevel, isAshtottari, isVimshottari, isChara]);
 
 
     // Navigation Methods (Refactored for Processed Tree)
@@ -410,9 +410,10 @@ export default function VedicDashasPage() {
             {/* ================================================================= */}
             {/* MAIN CONTENT - SPLIT LAYOUT */}
             {/* ================================================================= */}
-            <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 h-[500px]">
+            <div className={`grid grid-cols-1 lg:grid-cols-12 gap-3 h-[500px] ${isTrueChitra ? 'h-auto' : ''}`}>
 
-                {/* LEFT COLUMN - NATAL CHART */}
+                {/* LEFT COLUMN - NATAL CHART (hidden for True Chitra) */}
+                {!isTrueChitra && (
                 <div className="lg:col-span-4 h-full">
                     <div className="prem-card rounded-2xl overflow-hidden bg-surface-pure flex flex-col h-full">
                         <div className={cn("px-4 py-2 border-b border-gold-primary/15 flex justify-between items-center shrink-0", COLORS.wbSectionHeader)}>
@@ -438,9 +439,10 @@ export default function VedicDashasPage() {
                         </div>
                     </div>
                 </div>
+                )}
 
                 {/* RIGHT COLUMN - DASHA TABLE */}
-                <div className="lg:col-span-8 h-full flex flex-col min-h-0">
+                <div className={isTrueChitra ? "lg:col-span-12 h-full flex flex-col min-h-0" : "lg:col-span-8 h-full flex flex-col min-h-0"}>
                     <div className="prem-card overflow-hidden flex flex-col h-full">
                         {/* Selector Tray - Fixed Top */}
                         <div className="p-4 border-b border-gold-primary/10 flex flex-wrap items-center justify-between gap-4 shrink-0">
@@ -457,6 +459,10 @@ export default function VedicDashasPage() {
                                             if (settings.ayanamsa === 'KP' || settings.ayanamsa === 'Raman') {
                                                 return sys.id === 'vimshottari';
                                             }
+                                            if (settings.ayanamsa === 'TrueChitra') {
+                                                // True Chitra supports all 12 specialized dashas (no vimshottari, no chara)
+                                                return sys.id !== 'vimshottari' && sys.id !== 'chara';
+                                            }
                                             // Chara is now primarily a Lahiri/Jaimini feature
                                             return true;
                                         }).map((sys, idx) => (
@@ -469,10 +475,10 @@ export default function VedicDashasPage() {
                                 </div>
                             </div>
 
-                            {/* Level Tabs */}
-                            {allowMathematicalDrillDown && !isTribhagi && !isShodashottari && !isDwadashottari && !isPanchottari && !isChaturshitisama && !isSatabdika && !isDwisaptati && !isShasthihayani && (
+                            {/* Level Tabs — show only levels that exist in the data */}
+                            {allowMathematicalDrillDown && (
                                 <div className="flex gap-1 overflow-x-auto">
-                                    {DASHA_LEVELS.filter((_, idx) => !isTribhagi || idx <= 1).map((level, idx) => (
+                                    {DASHA_LEVELS.filter((_, idx) => idx <= maxAvailableLevel).map((level, idx) => (
                                         <button
                                             key={level.id}
                                             onClick={() => handleBreadcrumbClick(idx - 1)}
@@ -494,7 +500,7 @@ export default function VedicDashasPage() {
                         </div>
 
                         {/* Breadcrumbs - Fixed Top */}
-                        {!isTribhagi && !isShodashottari && !isDwadashottari && !isPanchottari && !isChaturshitisama && !isSatabdika && !isDwisaptati && (
+                        {maxAvailableLevel >= 1 && (
                             <div className="px-4 py-3 bg-surface-pure border-b border-gold-primary/10 flex items-center gap-2 overflow-x-auto shrink-0">
                                 <button
                                     onClick={() => handleBreadcrumbClick(-1)}

--- a/src/components/astrology/ChartControls.tsx
+++ b/src/components/astrology/ChartControls.tsx
@@ -18,8 +18,13 @@ export default function ChartControls() {
 
     const updateAyanamsa = (newAyanamsa: string) => {
         setAyanamsa(newAyanamsa as Ayanamsa);
-        // Redirect to Kundali (Overview) page if system changed
-        router.push('/vedic-astrology/overview');
+        // True Chitra is dasha-only — redirect to Dashas page
+        // Other systems redirect to Overview (Kundali)
+        if (newAyanamsa === 'TrueChitra') {
+            router.push('/vedic-astrology/dashas');
+        } else {
+            router.push('/vedic-astrology/overview');
+        }
     };
 
     const [showAdvanced, setShowAdvanced] = React.useState(false);
@@ -78,6 +83,7 @@ export default function ChartControls() {
                             { value: 'KP', label: 'KP' },
                             { value: 'Yukteswar', label: 'Sri Yukteswar' },
                             { value: 'Bhasin', label: 'Bhasin' },
+                            { value: 'TrueChitra', label: 'True Chitra' },
                         ]}
                     />
                     <p className="text-[9px] text-gold-dark/60 mt-2 italic">* This updates your global astrologer preferences.</p>

--- a/src/components/layout/GlobalSettingsModal.tsx
+++ b/src/components/layout/GlobalSettingsModal.tsx
@@ -15,6 +15,7 @@ const AYANAMSAS = [
     { id: 'Raman', label: 'Raman', desc: 'BV Raman traditional ayanamsa' },
     { id: 'Yukteswar', label: 'Sri Yukteswar', desc: 'Galactic Center based precision' },
     { id: 'Bhasin', label: 'Bhasin', desc: 'J.N. Bhasin ayanamsa system' },
+    { id: 'TrueChitra', label: 'True Chitra', desc: 'True Chitra ayanamsa — dasha-only system' },
 ];
 
 interface GlobalSettingsModalProps {
@@ -46,7 +47,12 @@ export default function GlobalSettingsModal({ onClose, router }: GlobalSettingsM
             onClose();
 
             if (systemChanged) {
-                router.push('/vedic-astrology/overview');
+                // True Chitra is dasha-only — redirect to Dashas page
+                if (tempSettings.ayanamsa === 'TrueChitra') {
+                    router.push('/vedic-astrology/dashas');
+                } else {
+                    router.push('/vedic-astrology/overview');
+                }
             }
         }, 600);
     };

--- a/src/components/vedic/VedicLayout.tsx
+++ b/src/components/vedic/VedicLayout.tsx
@@ -52,7 +52,7 @@ interface NavItem extends SidebarItem {
 const VEDIC_NAV_ITEMS: NavItem[] = [
     { name: "Kundali", path: "/overview", icon: LayoutTemplate },
     { name: "Divisional Charts", path: "/divisional", icon: Map, systemFilter: ['Lahiri', 'Raman', 'Yukteswar', 'Bhasin'] },
-    { name: "Dashas", path: "/dashas", icon: History, systemFilter: ['Lahiri', 'Raman', 'Yukteswar', 'Bhasin'] },
+    { name: "Dashas", path: "/dashas", icon: History, systemFilter: ['Lahiri', 'Raman', 'Yukteswar', 'Bhasin', 'TrueChitra'] },
     { name: "Yogas & Doshas", path: "/yoga-dosha", icon: Sparkles, systemFilter: ['Lahiri'] },
     { name: "Ashtakavargas", path: "/ashtakavarga", icon: Shield, systemFilter: ['Lahiri', 'Raman', 'Yukteswar', 'Bhasin'] },
     { name: "Shadbala", path: "/shadbala", icon: Orbit, systemFilter: ['Lahiri'] },
@@ -100,9 +100,9 @@ function VedicSubHeader({ clientDetails, setClientDetails, pathname, router, aya
         if (item.name === "Ashtakavargas" && !capabilities.hasAshtakavarga) return false;
         if (item.name === "Shadbala" && capabilities.features.shadbala.length === 0) return false;
         if (item.name === "Gochar" && !capabilities.charts.special.includes('transit')) return false;
-        if (item.name === "Sudarshan Chakra" && !capabilities.charts.special.includes('sudarshana')) return false;
+        if (item.name === "Sudarshan Chakra" && (!capabilities.charts.special.includes('sudarshana') || ayanamsa === 'TrueChitra')) return false;
         if (item.name === "KP System" && (!capabilities.hasHorary && ayanamsa !== 'KP')) return false;
-        if (item.name === "Kundali" && ayanamsa === 'KP') return false;
+        if (item.name === "Kundali" && (ayanamsa === 'KP' || ayanamsa === 'TrueChitra')) return false;
         if (item.systemFilter && !item.systemFilter.includes(ayanamsa)) return false;
         return true;
     });

--- a/src/context/VedicClientContext.tsx
+++ b/src/context/VedicClientContext.tsx
@@ -176,9 +176,38 @@ export function VedicClientProvider({ children }: { children: ReactNode }) {
     }, [clientDetails?.id]);
 
     // Persist Charts to Cache when fetched (ST-005)
+    // Excludes large dasha payloads to avoid QuotaExceededError
     useEffect(() => {
         if (clientDetails?.id && Object.keys(processedCharts).length > 0) {
-            sessionStorage.setItem(`${CHART_CACHE_KEY}_${clientDetails.id}`, JSON.stringify(processedCharts));
+            try {
+                // Strip large dasha data before caching — keep metadata only
+                const cacheable: ChartLookup = {};
+                for (const [key, chart] of Object.entries(processedCharts)) {
+                    if (key.startsWith('dasha_') || key.startsWith('dasha-')) {
+                        // Store dasha entries with truncated data (keep only first 2 items)
+                        const chartData = chart?.chartData;
+                        const truncatedData = Array.isArray(chartData)
+                            ? chartData.slice(0, 2)
+                            : typeof chartData === 'object' && chartData !== null
+                                ? { ...chartData, periods: Array.isArray((chartData as any).periods) ? (chartData as any).periods.slice(0, 2) : (chartData as any).periods }
+                                : chartData;
+                        cacheable[key] = {
+                            ...chart,
+                            chartData: truncatedData,
+                            _truncated: true,
+                        } as any;
+                    } else {
+                        cacheable[key] = chart;
+                    }
+                }
+                sessionStorage.setItem(`${CHART_CACHE_KEY}_${clientDetails.id}`, JSON.stringify(cacheable));
+            } catch (e) {
+                // Quota exceeded — clear cache and continue without caching
+                console.warn("[VedicClientContext] sessionStorage quota exceeded, skipping chart cache");
+                try {
+                    sessionStorage.removeItem(`${CHART_CACHE_KEY}_${clientDetails.id}`);
+                } catch {}
+            }
         }
     }, [processedCharts, clientDetails?.id]);
 

--- a/src/lib/api/clients.ts
+++ b/src/lib/api/clients.ts
@@ -307,6 +307,25 @@ export const clientApi = {
                 hasCompatibility: false,
                 hasHorary: false,
             },
+            true_chitra: {
+                charts: {
+                    divisional: [],
+                    special: [],
+                    lagna: []
+                },
+                features: {
+                    dasha: ['prana', 'ashtottari', 'tribhagi', 'tribhagi_40', 'shodashottari', 'dwadashottari', 'dwisaptati', 'shastihayani', 'shattrimshatsama', 'panchottari', 'satabdika', 'chaturshitisama'],
+                    ashtakavarga: [],
+                    shadbala: [],
+                    compatibility: [],
+                    numerology: []
+                },
+                hasDivisional: false,
+                hasAshtakavarga: false,
+                hasNumerology: false,
+                hasCompatibility: false,
+                hasHorary: false,
+            },
         };
         return CAPABILITIES[system.toLowerCase()] || CAPABILITIES.lahiri;
     },

--- a/src/lib/dasha-utils/period-extraction.ts
+++ b/src/lib/dasha-utils/period-extraction.ts
@@ -42,6 +42,7 @@ export function getSublevels(node: RawDashaPeriod): RawDashaPeriod[] | null {
         node.sookshmadashas ||
         node.prandashas ||
         node.pran_dashas ||
+        node.sub_periods ||
         node.sublevel ||
         node.timeline ||
         node.periods;
@@ -62,13 +63,13 @@ export function resolvePlanetName(p: RawDashaPeriod): string {
 export function resolveStartDate(p: RawDashaPeriod): string {
     return p.start_date || p.startDate || p.start || p.starting || p.starting_date ||
         p.beginning || p.beginning_date || p.mahadasha_beginning || p.mahadasha_starting_date ||
-        p.from || p.from_date;
+        p.from || p.from_date || p.start_date_utc;
 }
 
 /** Resolve end date from a raw period record */
 export function resolveEndDate(p: RawDashaPeriod): string {
     return p.end_date || p.endDate || p.end || p.ending || p.ending_date ||
-        p.mahadasha_ending || p.mahadasha_ending_date || p.to || p.to_date;
+        p.mahadasha_ending || p.mahadasha_ending_date || p.to || p.to_date || p.end_date_utc;
 }
 
 /**
@@ -125,6 +126,19 @@ export function extractPeriodsArray(data: RawDashaPeriod | RawDashaPeriod[]): Ra
                     planet: a.lord, startDate: a.start_date, endDate: a.end_date, raw: a
                 }))
             }));
+        }
+
+        // True Chitra Ashtottari: nested inside ashtottari_data.dasha_sequence
+        if (data.ashtottari_data && data.ashtottari_data.dasha_sequence && Array.isArray(data.ashtottari_data.dasha_sequence)) {
+            return data.ashtottari_data.dasha_sequence;
+        }
+
+        // True Chitra Prana Dasha / recursive sub_periods structures
+        if (data.prana_dasha && Array.isArray(data.prana_dasha)) {
+            return data.prana_dasha;
+        }
+        if (data.sub_periods && Array.isArray(data.sub_periods)) {
+            return data.sub_periods;
         }
 
         // Generic timeline/dasha_table fallback

--- a/src/lib/dasha-utils/tree-processing.ts
+++ b/src/lib/dasha-utils/tree-processing.ts
@@ -59,12 +59,49 @@ function mapDashaLevelRecursive(node: RawDashaPeriod, level: number, inheritedSt
     };
 }
 
+/** Detect how many levels deep the raw dasha data goes */
+function detectDashaDepth(node: RawDashaPeriod, currentDepth: number = 0): number {
+    if (!node) return currentDepth;
+    const children = getSublevels(node);
+    if (!Array.isArray(children) || children.length === 0) {
+        return currentDepth;
+    }
+    // Find the deepest child
+    let maxChildDepth = currentDepth + 1;
+    for (const child of children) {
+        const childDepth = detectDashaDepth(child, currentDepth + 1);
+        if (childDepth > maxChildDepth) maxChildDepth = childDepth;
+    }
+    return maxChildDepth;
+}
+
+/** Auto-detect max level by scanning all periods for the deepest tree */
+function autoDetectMaxLevel(data: RawDashaPeriod): number {
+    const periods = extractPeriodsArray(data);
+    if (periods.length === 0) return 4; // Default fallback
+    // Scan all periods to find the maximum depth (first period may be a balance period with fewer levels)
+    let maxDepth = 0;
+    for (const period of periods) {
+        const depth = detectDashaDepth(period, 0);
+        if (depth > maxDepth) maxDepth = depth;
+    }
+    // depth 0 = no children → maxLevel 0 (just maha)
+    // depth 1 = maha + antar → maxLevel 1
+    // depth 2 = maha + antar + pratyantar → maxLevel 2
+    // depth 3 = maha + antar + pratyantar + sookshma → maxLevel 3
+    // depth 4 = maha + antar + pratyantar + sookshma + prana → maxLevel 4
+    return maxDepth;
+}
+
 /** Process the full API response into a standardized Dasha tree */
-export function processDashaResponse(data: RawDashaPeriod, maxLevel: number = 4): DashaNode[] {
+export function processDashaResponse(data: RawDashaPeriod, maxLevel?: number): DashaNode[] {
     if (!data) return [];
 
     const periods = extractPeriodsArray(data);
     if (periods.length === 0) return [];
+
+    // Auto-detect depth if maxLevel not provided
+    const effectiveMaxLevel = maxLevel !== undefined ? maxLevel : autoDetectMaxLevel(data);
 
     let currentStart = '';
 
@@ -84,7 +121,7 @@ export function processDashaResponse(data: RawDashaPeriod, maxLevel: number = 4)
     return periods.map((m: RawDashaPeriod) => {
         const s = m.start_date || m.start;
         if (s) currentStart = s;
-        const mapped = mapDashaLevelRecursive(m, 0, currentStart, maxLevel);
+        const mapped = mapDashaLevelRecursive(m, 0, currentStart, effectiveMaxLevel);
         const e = m.end_date || m.end;
         if (e) currentStart = e;
         return mapped;

--- a/src/store/useAstrologerStore.ts
+++ b/src/store/useAstrologerStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
-export type Ayanamsa = "Lahiri" | "Raman" | "KP" | "Yukteswar" | "Bhasin";
+export type Ayanamsa = "Lahiri" | "Raman" | "KP" | "Yukteswar" | "Bhasin" | "TrueChitra";
 export type ChartStyle = "North Indian" | "South Indian";
 export type ChartColorTheme = "classic" | "modern" | "royal" | "earth" | "ocean";
 


### PR DESCRIPTION
- Add TrueChitra to ayanamsa types, options, and hierarchy
- Route True Chitra dasha calls to correct Python endpoints
- Auto-detect dasha depth from JSON response (shows pratyantar, sookshma, prana as available)
- Handle True Chitra nested JSON structures (ashtottari_data.dasha_sequence, sub_periods)
- Support UTC date fields (start_date_utc, end_date_utc) for Dwisaptati
- True Chitra uses generic planet table (same as Vimshottari/Lahiri rendering)
- Redirect to Dashas page when switching to True Chitra ayanamsa
- Hide natal chart sidebar and non-dasha navigation for True Chitra
- Add storage quota protection for large dasha responses