### PR TITLE
feat(lesson): redesigned lesson header, sidebar, flashcards, and sect…

### DIFF
--- a/src/app/learn/lesson/[id]/page.tsx
+++ b/src/app/learn/lesson/[id]/page.tsx
@@ -93,7 +93,7 @@ export default function LessonPage() {
     const InteractiveComponent = INTERACTIVE_MAP[interactiveKey];
     return (
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50">
-        <div className="w-full py-6">
+        <div className="w-full pb-6">
           <Suspense fallback={
             <div className="flex items-center justify-center py-20">
               <div className="w-12 h-12 border-4 border-amber-200 border-t-amber-600 rounded-full animate-spin" />

--- a/src/components/learn/interactive/Flashcard.tsx
+++ b/src/components/learn/interactive/Flashcard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React, { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { RotateCcw, ChevronLeft, ChevronRight } from "lucide-react";
+import { motion } from "framer-motion";
+import { RotateCcw } from "lucide-react";
 
 interface FlashcardData {
   id: string | number;
@@ -29,7 +29,7 @@ function SingleFlashcard({ card }: { card: FlashcardData }) {
   return (
     <div
       className="relative w-full cursor-pointer"
-      style={{ perspective: "1200px" }}
+      style={{ perspective: "1000px" }}
       onClick={() => setIsFlipped(!isFlipped)}
       role="button"
       tabIndex={0}
@@ -49,19 +49,16 @@ function SingleFlashcard({ card }: { card: FlashcardData }) {
       >
         {/* Front */}
         <div
-          className="relative rounded-2xl border-2 border-amber-200 bg-white px-6 py-7 flex flex-col items-center justify-center text-center shadow-lg"
+          className="relative rounded-2xl border-2 border-amber-200 bg-white px-5 py-5 flex flex-col items-center justify-center text-center shadow-sm min-h-[180px]"
           style={{ backfaceVisibility: "hidden" }}
         >
           {card.category && (
-            <span className="text-[10px] font-bold uppercase tracking-wider text-amber-500 mb-3 px-3 py-1 bg-amber-100 rounded-full">
+            <span className="text-[10px] font-bold uppercase tracking-wider text-amber-500 mb-2 px-3 py-1 bg-amber-50 rounded-full border border-amber-100">
               {card.category}
             </span>
           )}
-          <div className="w-10 h-10 rounded-full bg-amber-50 border border-amber-200 flex items-center justify-center mb-3">
-            <span className="text-lg">❓</span>
-          </div>
-          <p className="text-lg font-bold text-gray-900 leading-snug">{card.front}</p>
-          <p className="text-xs text-gray-400 mt-4 flex items-center gap-1.5">
+          <p className="text-base font-bold text-gray-900 leading-snug">{card.front}</p>
+          <p className="text-xs text-gray-400 mt-3 flex items-center gap-1.5">
             <RotateCcw className="w-3 h-3" />
             Tap to reveal
           </p>
@@ -69,34 +66,34 @@ function SingleFlashcard({ card }: { card: FlashcardData }) {
 
         {/* Back */}
         <div
-          className="absolute inset-0 rounded-2xl border-2 border-emerald-200 bg-white px-5 py-5 flex flex-col items-center shadow-lg overflow-y-auto"
+          className="absolute inset-0 rounded-2xl border-2 border-emerald-200 bg-white px-3 py-3 flex flex-col items-center justify-center shadow-sm overflow-y-auto"
           style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
         >
-          <span className="text-[10px] font-bold uppercase tracking-wider text-emerald-500 mb-2 px-3 py-1 bg-emerald-100 rounded-full shrink-0">
+          <span className="text-[10px] font-bold uppercase tracking-wider text-emerald-600 mb-2 px-2.5 py-0.5 bg-emerald-50 rounded-full border border-emerald-100 shrink-0">
             Answer
           </span>
 
           {isListAnswer ? (
-            <div className="w-full space-y-1.5">
+            <div className="w-full grid grid-cols-2 gap-2">
               {backItems.map((item, i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-2.5 p-2 rounded-lg bg-emerald-50/60 border border-emerald-100 text-left"
+                  className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 border border-gray-100"
                 >
-                  <span className="w-5 h-5 rounded-full bg-emerald-200 text-emerald-700 flex items-center justify-center text-[10px] font-bold shrink-0">
+                  <span className="w-6 h-6 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center text-[11px] font-bold shrink-0">
                     {i + 1}
                   </span>
-                  <span className="text-sm font-medium text-gray-800 leading-snug">{item}</span>
+                  <span className="text-xs font-semibold text-gray-800 leading-snug">{item}</span>
                 </div>
               ))}
             </div>
           ) : (
-            <p className="text-base font-medium text-gray-900 leading-relaxed text-center px-2">
+            <p className="text-sm font-semibold text-gray-900 leading-relaxed text-center px-1">
               {card.back}
             </p>
           )}
 
-          <p className="text-xs text-gray-400 mt-3 flex items-center gap-1.5 shrink-0">
+          <p className="text-[10px] text-gray-400 mt-2 flex items-center gap-1 shrink-0">
             <RotateCcw className="w-3 h-3" />
             Tap to flip back
           </p>
@@ -107,23 +104,10 @@ function SingleFlashcard({ card }: { card: FlashcardData }) {
 }
 
 /**
- * Flashcard carousel component with flip animation.
- * Supports multiple cards with navigation.
+ * Flashcard grid — all cards visible, each flips independently.
  */
 export default function Flashcard({ cards, className = "" }: FlashcardProps) {
-  const [currentIndex, setCurrentIndex] = useState(0);
-
   if (cards.length === 0) return null;
-
-  const goNext = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setCurrentIndex((i) => (i + 1) % cards.length);
-  };
-
-  const goPrev = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setCurrentIndex((i) => (i - 1 + cards.length) % cards.length);
-  };
 
   return (
     <motion.div
@@ -133,62 +117,10 @@ export default function Flashcard({ cards, className = "" }: FlashcardProps) {
       transition={{ duration: 0.5 }}
       className={`${className}`}
     >
-      <div className="relative">
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={currentIndex}
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.95 }}
-            transition={{ duration: 0.25 }}
-          >
-            <SingleFlashcard card={cards[currentIndex]} />
-          </motion.div>
-        </AnimatePresence>
-
-        {/* Navigation */}
-        {cards.length > 1 && (
-          <div className="flex items-center justify-center gap-4 mt-4">
-            <button
-              onClick={goPrev}
-              className="p-2 rounded-xl bg-white border border-amber-200 hover:bg-amber-50 text-amber-700 transition-colors shadow-sm"
-              aria-label="Previous card"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </button>
-
-            <div className="flex items-center gap-1.5">
-              {cards.map((_, idx) => (
-                <button
-                  key={idx}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setCurrentIndex(idx);
-                  }}
-                  className={`w-2 h-2 rounded-full transition-all ${
-                    idx === currentIndex
-                      ? "bg-amber-500 w-6"
-                      : "bg-amber-200 hover:bg-amber-300"
-                  }`}
-                  aria-label={`Go to card ${idx + 1}`}
-                />
-              ))}
-            </div>
-
-            <button
-              onClick={goNext}
-              className="p-2 rounded-xl bg-white border border-amber-200 hover:bg-amber-50 text-amber-700 transition-colors shadow-sm"
-              aria-label="Next card"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </button>
-          </div>
-        )}
-
-        {/* Counter */}
-        <p className="text-center text-xs text-amber-400 mt-2">
-          {currentIndex + 1} of {cards.length}
-        </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {cards.map((card) => (
+          <SingleFlashcard key={card.id} card={card} />
+        ))}
       </div>
     </motion.div>
   );

--- a/src/components/learn/interactive/LessonHeader.tsx
+++ b/src/components/learn/interactive/LessonHeader.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { motion } from "framer-motion";
+import {
+  CheckCircle2,
+  Lock,
+  Clock,
+  Lightbulb,
+  BrainCircuit,
+  BookOpen,
+  GraduationCap,
+  Target,
+} from "lucide-react";
+
+/* ─── Types ─── */
+export interface LessonHeaderProps {
+  title: string;
+  lessonNumber: number;
+  moduleNumber: number;
+  chapterNumber: number;
+  chapterTitle?: string;
+  isCompleted?: boolean;
+  isLocked?: boolean;
+  allText: string;
+  conceptCount: number;
+  quizCount: number;
+  bestScore?: number;
+  attemptsCount?: number;
+  progress?: number;
+}
+
+/* ─── Helpers ─── */
+function getWordCount(text: string) {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+function getReadingMinutes(text: string, wpm = 200) {
+  return Math.max(1, Math.ceil(getWordCount(text) / wpm));
+}
+
+/* ─── Circular Progress Ring ─── */
+function ProgressRing({
+  progress,
+  size = 48,
+  stroke = 4,
+}: {
+  progress: number;
+  size?: number;
+  stroke?: number;
+}) {
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - progress / 100);
+  const isComplete = progress >= 100;
+
+  return (
+    <div className="relative flex items-center justify-center" style={{ width: size, height: size }}>
+      <svg width={size} height={size} className="-rotate-90">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          className="stroke-gray-200"
+          strokeWidth={stroke}
+        />
+        <motion.circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          className={isComplete ? "stroke-emerald-500" : "stroke-amber-500"}
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          initial={{ strokeDashoffset: circumference }}
+          animate={{ strokeDashoffset: offset }}
+          transition={{ duration: 0.8, ease: "easeOut" }}
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        {isComplete ? (
+          <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+        ) : (
+          <>
+            <span className="text-[11px] font-extrabold text-gray-700 leading-none">{progress}</span>
+            <span className="text-[7px] font-bold text-gray-400 leading-none">%</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Component ─── */
+export default function LessonHeader({
+  title,
+  lessonNumber,
+  moduleNumber,
+  chapterNumber,
+  chapterTitle,
+  isCompleted = false,
+  isLocked = false,
+  allText,
+  conceptCount,
+  quizCount,
+  bestScore = 0,
+  attemptsCount = 0,
+  progress = 0,
+}: LessonHeaderProps) {
+  const minutes = useMemo(() => getReadingMinutes(allText), [allText]);
+
+  return (
+    <motion.div
+      id="hero"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="py-2"
+    >
+      <div className="flex items-center gap-3">
+        {/* Left content */}
+        <div className="flex-1 min-w-0">
+          {/* Breadcrumbs + meta */}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-1">
+            <div className="inline-flex items-center gap-1 text-[10px] font-bold text-amber-700 uppercase tracking-wide">
+              <GraduationCap className="w-3 h-3" />
+              Lesson {lessonNumber}
+            </div>
+            <div className="inline-flex items-center gap-1 text-[10px] font-semibold text-amber-600">
+              <BookOpen className="w-3 h-3" />
+              Module {String(moduleNumber).padStart(2, "0")}
+              {chapterNumber > 0 && (
+                <>
+                  <span className="text-amber-300">·</span>
+                  Ch.{chapterNumber}
+                </>
+              )}
+              {chapterTitle && <span className="text-amber-400">— {chapterTitle}</span>}
+            </div>
+
+            <div className="hidden sm:flex items-center gap-2 text-[10px] text-gray-400">
+              <span className="flex items-center gap-0.5"><Clock className="w-3 h-3" /> {minutes} min</span>
+              <span>·</span>
+              <span className="flex items-center gap-0.5"><Lightbulb className="w-3 h-3" /> {conceptCount}</span>
+              <span>·</span>
+              <span className="flex items-center gap-0.5"><BrainCircuit className="w-3 h-3" /> {quizCount}</span>
+            </div>
+
+            <div className="flex-1" />
+
+            {isCompleted && (
+              <span className="inline-flex items-center gap-1 text-[10px] font-bold text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded-full border border-emerald-200/60">
+                <CheckCircle2 className="w-3 h-3" /> Completed
+              </span>
+            )}
+            {isLocked && (
+              <span className="inline-flex items-center gap-1 text-[10px] font-bold text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded-full border border-gray-200/60">
+                <Lock className="w-3 h-3" /> Locked
+              </span>
+            )}
+          </div>
+
+          {/* Title */}
+          <h1 className="text-lg sm:text-xl lg:text-2xl font-extrabold text-amber-950 leading-snug tracking-tight">
+            {title}
+          </h1>
+        </div>
+
+
+      </div>
+
+      {/* Previous attempt — compact row */}
+      {bestScore > 0 && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2 }}
+          className="mt-1.5 flex items-center gap-2 text-[10px] text-gray-500"
+        >
+          <span className="font-medium">Best: {bestScore}%</span>
+          <span className="text-gray-300">·</span>
+          <span>{attemptsCount} attempt{attemptsCount !== 1 ? "s" : ""}</span>
+        </motion.div>
+      )}
+    </motion.div>
+  );
+}

--- a/src/components/learn/interactive/LessonSidebar.tsx
+++ b/src/components/learn/interactive/LessonSidebar.tsx
@@ -17,6 +17,11 @@ import {
   ChevronRight,
   Menu,
   X,
+  Rocket,
+  GraduationCap,
+  Dumbbell,
+  Flag,
+  Sparkles,
   type LucideIcon,
 } from "lucide-react";
 
@@ -34,30 +39,105 @@ interface LessonSidebarProps {
   onNavigate: (sectionId: string) => void;
   progress: number;
   className?: string;
+  showProgress?: boolean;
 }
 
-// ─── Icon mapping: each section type gets a UNIQUE, semantic icon ───
-const TYPE_ICONS: Record<string, LucideIcon> = {
-  overview: LayoutList,     // List/overview view
-  definition: BookText,     // Text/definition document
-  etymology: Languages,     // Language/translation
-  mechanics: Cog,           // Settings/mechanics
-  concepts: Lightbulb,      // Ideas/concepts
-  quiz: CircleHelp,         // Questions/quiz
-  recap: RotateCcw,         // Review/recap
-  flashcards: Layers,       // Stack of cards
-  practice: Trophy,         // Achievement/practice
-  continue: ArrowRight,     // Next/continue
+/* ─── Color tokens per section type ─── */
+const TYPE_STYLES: Record<
+  string,
+  { icon: LucideIcon; color: string; bg: string; border: string; ring: string; activeBg: string }
+> = {
+  overview:   { icon: LayoutList,  color: "text-sky-600",     bg: "bg-sky-50",     border: "border-sky-200",     ring: "stroke-sky-500",     activeBg: "bg-sky-500" },
+  definition: { icon: BookText,    color: "text-indigo-600",  bg: "bg-indigo-50",  border: "border-indigo-200",  ring: "stroke-indigo-500",  activeBg: "bg-indigo-500" },
+  etymology:  { icon: Languages,   color: "text-violet-600",  bg: "bg-violet-50",  border: "border-violet-200",  ring: "stroke-violet-500",  activeBg: "bg-violet-500" },
+  mechanics:  { icon: Cog,         color: "text-amber-600",   bg: "bg-amber-50",   border: "border-amber-200",   ring: "stroke-amber-500",   activeBg: "bg-amber-500" },
+  concepts:   { icon: Lightbulb,   color: "text-emerald-600", bg: "bg-emerald-50", border: "border-emerald-200", ring: "stroke-emerald-500", activeBg: "bg-emerald-500" },
+  quiz:       { icon: CircleHelp,  color: "text-rose-600",    bg: "bg-rose-50",    border: "border-rose-200",    ring: "stroke-rose-500",    activeBg: "bg-rose-500" },
+  recap:      { icon: RotateCcw,   color: "text-cyan-600",    bg: "bg-cyan-50",    border: "border-cyan-200",    ring: "stroke-cyan-500",    activeBg: "bg-cyan-500" },
+  flashcards: { icon: Layers,      color: "text-purple-600",  bg: "bg-purple-50",  border: "border-purple-200",  ring: "stroke-purple-500",  activeBg: "bg-purple-500" },
+  practice:   { icon: Trophy,      color: "text-orange-600",  bg: "bg-orange-50",  border: "border-orange-200",  ring: "stroke-orange-500",  activeBg: "bg-orange-500" },
+  continue:   { icon: ArrowRight,  color: "text-teal-600",    bg: "bg-teal-50",    border: "border-teal-200",    ring: "stroke-teal-500",    activeBg: "bg-teal-500" },
 };
 
-// ─── Group labels with order ───
-const GROUP_ORDER = ["Start", "Learn", "Practice", "Finish"];
-const GROUP_LABELS: Record<string, string> = {
-  Start: "Start",
-  Learn: "Core Content",
-  Practice: "Practice",
-  Finish: "Wrap Up",
+/* ─── Group metadata ─── */
+const GROUP_META: Record<string, { label: string; icon: LucideIcon; accent: string; bg: string }> = {
+  Start:    { label: "Orientation",   icon: Rocket,          accent: "text-sky-600",     bg: "bg-sky-50" },
+  Learn:    { label: "Core Knowledge", icon: GraduationCap,  accent: "text-amber-700",   bg: "bg-amber-50" },
+  Practice: { label: "Practice",       icon: Dumbbell,       accent: "text-emerald-600", bg: "bg-emerald-50" },
+  Finish:   { label: "Wrap Up",        icon: Flag,           accent: "text-violet-600",  bg: "bg-violet-50" },
 };
+
+const GROUP_ORDER = ["Start", "Learn", "Practice", "Finish"];
+
+/* ─── Motivational message based on progress ─── */
+function getMotivation(progress: number): string {
+  if (progress === 0)   return "Every expert was once a beginner. Let's begin!";
+  if (progress < 25)    return "Great start! The journey of a thousand miles…";
+  if (progress < 50)    return "You're building momentum. Keep going!";
+  if (progress < 75)    return "More than halfway! You're doing amazing.";
+  if (progress < 100)   return "Almost there! Final push to mastery.";
+  return "Lesson complete! You've unlocked new wisdom.";
+}
+
+/* ─── Circular Progress Ring ─── */
+function ProgressRing({
+  progress,
+  size = 72,
+  stroke = 6,
+}: {
+  progress: number;
+  size?: number;
+  stroke?: number;
+}) {
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - progress / 100);
+  const isComplete = progress >= 100;
+
+  return (
+    <div className="relative flex items-center justify-center" style={{ width: size, height: size }}>
+      <svg width={size} height={size} className="-rotate-90">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          className="stroke-gray-100"
+          strokeWidth={stroke}
+        />
+        <motion.circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          className={isComplete ? "stroke-emerald-500" : "stroke-amber-500"}
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          initial={{ strokeDashoffset: circumference }}
+          animate={{ strokeDashoffset: offset }}
+          transition={{ duration: 0.8, ease: "easeOut" }}
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        {isComplete ? (
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ type: "spring", stiffness: 300, damping: 15 }}
+          >
+            <CheckCircle2 className="w-6 h-6 text-emerald-500" />
+          </motion.div>
+        ) : (
+          <>
+            <span className="text-lg font-extrabold text-gray-800 leading-none">{progress}</span>
+            <span className="text-[9px] font-bold text-gray-400 leading-none mt-0.5">%</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export default function LessonSidebar({
   sections,
@@ -66,6 +146,7 @@ export default function LessonSidebar({
   onNavigate,
   progress,
   className = "",
+  showProgress = true,
 }: LessonSidebarProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -74,7 +155,7 @@ export default function LessonSidebar({
     setMobileOpen(false);
   };
 
-  // Group sections — normalize group names to Title Case to prevent casing mismatches
+  // Normalize group names
   const normalizeGroup = (g: string) => {
     const map: Record<string, string> = {
       start: "Start", learn: "Learn", practice: "Practice", finish: "Finish",
@@ -82,6 +163,7 @@ export default function LessonSidebar({
     };
     return map[g] || g;
   };
+
   const grouped = sections.reduce<Record<string, SidebarSection[]>>((acc, s) => {
     const g = normalizeGroup(s.group || "Learn");
     if (!acc[g]) acc[g] = [];
@@ -92,105 +174,154 @@ export default function LessonSidebar({
   const renderItem = (section: SidebarSection) => {
     const isActive = activeSection === section.id;
     const isCompleted = completedSections.has(section.id);
-    const Icon = TYPE_ICONS[section.type || ""] || ChevronRight;
+    const styles = TYPE_STYLES[section.type || ""] || TYPE_STYLES.overview;
+    const Icon = styles.icon;
 
     return (
-      <button
+      <motion.button
         key={section.id}
         onClick={() => handleNavigate(section.id)}
-        className={`w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-left text-[13px] transition-all duration-150 relative ${
+        whileHover={{ x: 2 }}
+        whileTap={{ scale: 0.98 }}
+        className={`w-full flex items-center gap-3 px-3 py-2 rounded-xl text-left text-[13px] transition-colors duration-200 relative group ${
           isActive
-            ? "bg-amber-50 text-amber-900 font-semibold shadow-sm border-l-2 border-l-amber-500"
+            ? `${styles.bg} ${styles.color} font-semibold shadow-sm ring-1 ${styles.border}`
             : isCompleted
-            ? "text-gray-800 hover:bg-gray-50"
-            : "text-gray-800 hover:bg-gray-50 hover:text-gray-900"
+            ? "text-gray-700 hover:bg-gray-50/80"
+            : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
         }`}
         aria-current={isActive ? "true" : undefined}
       >
-        {/* Icon with completion badge */}
+        {/* Icon container */}
         <span className="relative shrink-0">
           <span
-            className={`w-6 h-6 rounded-md flex items-center justify-center ${
+            className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all duration-200 ${
               isActive
-                ? "bg-amber-500 text-white"
+                ? `${styles.activeBg} text-white shadow-md`
                 : isCompleted
-                ? "bg-green-100 text-green-600"
-                : "bg-gray-100 text-gray-400"
+                ? `${styles.bg} ${styles.color} ring-1 ${styles.border}`
+                : "bg-gray-100 text-gray-400 group-hover:bg-white group-hover:ring-1 group-hover:ring-gray-200"
             }`}
           >
             <Icon className="w-3.5 h-3.5" />
           </span>
-          {/* Completion checkmark badge */}
+          {/* Completed checkmark */}
           {isCompleted && !isActive && (
-            <span className="absolute -top-0.5 -right-0.5 w-3 h-3 bg-green-500 rounded-full flex items-center justify-center border border-white">
-              <CheckCircle2 className="w-2 h-2 text-white" />
-            </span>
+            <motion.span
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 bg-emerald-500 rounded-full flex items-center justify-center border-2 border-white shadow-sm"
+            >
+              <CheckCircle2 className="w-2.5 h-2.5 text-white" />
+            </motion.span>
           )}
         </span>
 
         {/* Label */}
-        <span className="truncate flex-1">{section.label}</span>
+        <span className="flex-1 font-medium leading-snug">{section.label}</span>
 
-        {/* Active indicator dot */}
+        {/* Active sparkle */}
         {isActive && (
           <motion.div
-            layoutId="sidebar-active"
-            className="w-1.5 h-1.5 rounded-full bg-amber-500"
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
             transition={{ type: "spring", stiffness: 500, damping: 30 }}
-          />
+          >
+            <Sparkles className={`w-3.5 h-3.5 ${styles.color}`} />
+          </motion.div>
         )}
-      </button>
+      </motion.button>
     );
   };
 
   const sidebarContent = (
-    <div className="space-y-3" role="navigation" aria-label="Lesson sections">
-      {GROUP_ORDER.filter((g) => grouped[g]?.length > 0).map((group) => (
-        <div key={group}>
-          <p className="text-[10px] font-bold text-gray-700 uppercase tracking-wider px-2.5 mb-1">
-            {GROUP_LABELS[group]}
-          </p>
-          <div className="space-y-0.5">
-            {grouped[group].map(renderItem)}
+    <div className="space-y-5" role="navigation" aria-label="Lesson sections">
+      {GROUP_ORDER.filter((g) => grouped[g]?.length > 0).map((group) => {
+        const meta = GROUP_META[group];
+        const GroupIcon = meta.icon;
+        const groupCompleted = grouped[group].every((s) => completedSections.has(s.id));
+        const groupProgress = Math.round(
+          (grouped[group].filter((s) => completedSections.has(s.id)).length /
+            grouped[group].length) *
+            100
+        );
+
+        return (
+          <div key={group}>
+            {/* Group header */}
+            <div className="flex items-center gap-2 px-3 mb-2">
+              <div
+                className={`w-6 h-6 rounded-md flex items-center justify-center ${meta.bg}`}
+              >
+                <GroupIcon className={`w-3.5 h-3.5 ${meta.accent}`} />
+              </div>
+              <span className={`text-[10px] font-bold uppercase tracking-widest ${meta.accent}`}>
+                {meta.label}
+              </span>
+              {groupCompleted && (
+                <motion.span
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  className="ml-auto"
+                >
+                  <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
+                </motion.span>
+              )}
+              {!groupCompleted && groupProgress > 0 && (
+                <span className="ml-auto text-[9px] font-semibold text-gray-400">
+                  {groupProgress}%
+                </span>
+              )}
+              {/* Decorative line */}
+              <div className="flex-1 h-px bg-gray-100 ml-2" />
+            </div>
+
+            {/* Items */}
+            <div className="space-y-1">
+              {grouped[group].map(renderItem)}
+            </div>
           </div>
-        </div>
-      ))}
-      {/* Ungrouped sections (fallback) */}
+        );
+      })}
+      {/* Ungrouped fallback */}
       {(grouped[undefined as unknown as string] || []).map(renderItem)}
+    </div>
+  );
+
+  const progressCard = (
+    <div className="bg-white rounded-2xl border border-gray-200/80 p-4 shadow-sm">
+      <div className="flex items-center gap-4">
+        <ProgressRing progress={progress} size={68} stroke={5.5} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-[10px] font-bold text-gray-500 uppercase tracking-widest">
+              Your Progress
+            </span>
+          </div>
+          <p className="text-[11px] text-gray-500 leading-snug italic">
+            {getMotivation(progress)}
+          </p>
+        </div>
+      </div>
     </div>
   );
 
   return (
     <>
-      {/* Desktop sidebar */}
+      {/* ─── Desktop sidebar ─── */}
       <div className={`hidden lg:block ${className}`}>
         <div className="max-h-[calc(100vh-2rem)] overflow-y-auto no-scrollbar space-y-3 pr-1 pb-4">
           {/* Progress card */}
-          <div className="bg-white rounded-xl border border-gray-200/70 p-3.5 shadow-sm">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-[10px] font-bold text-gray-700 uppercase tracking-wider">
-                Progress
-              </span>
-              <span className="text-xs font-bold text-amber-600">{progress}%</span>
-            </div>
-            <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
-              <motion.div
-                className="h-full bg-gradient-to-r from-amber-500 to-orange-500 rounded-full"
-                initial={{ width: 0 }}
-                animate={{ width: `${progress}%` }}
-                transition={{ duration: 0.5, ease: "easeOut" }}
-              />
-            </div>
-          </div>
+          {showProgress && progressCard}
 
           {/* Sections nav */}
-          <div className="bg-white rounded-xl border border-gray-200/70 p-3 shadow-sm">
+          <div className="bg-white rounded-2xl border border-gray-200/80 p-4 shadow-sm">
             {sidebarContent}
           </div>
         </div>
       </div>
 
-      {/* Mobile floating nav */}
+      {/* ─── Mobile floating nav ─── */}
       <div className="lg:hidden">
         <button
           onClick={() => setMobileOpen(true)}
@@ -213,30 +344,38 @@ export default function LessonSidebar({
           {mobileOpen && (
             <>
               <motion.div
-                initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
                 className="fixed inset-0 z-[60] bg-black/40 backdrop-blur-sm"
                 onClick={() => setMobileOpen(false)}
               />
               <motion.div
-                initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
+                initial={{ y: "100%" }}
+                animate={{ y: 0 }}
+                exit={{ y: "100%" }}
                 transition={{ type: "spring", stiffness: 300, damping: 30 }}
-                className="fixed bottom-0 left-0 right-0 z-[61] bg-white rounded-t-3xl shadow-2xl max-h-[75vh] overflow-y-auto"
+                className="fixed bottom-0 left-0 right-0 z-[61] bg-white rounded-t-3xl shadow-2xl max-h-[80vh] overflow-y-auto"
               >
                 <div className="p-5">
                   <div className="flex items-center justify-between mb-4">
                     <h3 className="text-sm font-bold text-gray-800 uppercase tracking-wide">
                       Lesson Sections
                     </h3>
-                    <button onClick={() => setMobileOpen(false)} className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors" aria-label="Close navigation">
+                    <button
+                      onClick={() => setMobileOpen(false)}
+                      className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+                      aria-label="Close navigation"
+                    >
                       <X className="w-5 h-5 text-gray-500" />
                     </button>
                   </div>
-                  <div className="flex items-center gap-3 mb-4 p-3 bg-gray-50 rounded-xl">
-                    <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
-                      <div className="h-full bg-gradient-to-r from-amber-400 to-orange-500 rounded-full transition-all" style={{ width: `${progress}%` }} />
-                    </div>
-                    <span className="text-xs font-bold text-amber-700">{progress}%</span>
+
+                  {/* Mobile progress */}
+                  <div className="mb-5">
+                    {progressCard}
                   </div>
+
                   {sidebarContent}
                 </div>
               </motion.div>

--- a/src/components/learn/module1/Lesson1Interactive.tsx
+++ b/src/components/learn/module1/Lesson1Interactive.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import {
-  ArrowLeft, GraduationCap, CheckCircle2, Lock, ChevronRight,
+  CheckCircle2, Lock, ChevronRight,
   BookOpen, Layers, Sparkles, BrainCircuit, Target,
   Lightbulb, Play, Compass, Globe,
 } from "lucide-react";
@@ -15,8 +15,8 @@ import { useReadingProgress } from "@/hooks/useReadingProgress";
 
 import ScrollProgress from "@/components/learn/interactive/ScrollProgress";
 import LessonSidebar, { type SidebarSection } from "@/components/learn/interactive/LessonSidebar";
+import LessonHeader from "@/components/learn/interactive/LessonHeader";
 import CalloutBlock from "@/components/learn/interactive/CalloutBlock";
-import ReadingTime from "@/components/learn/interactive/ReadingTime";
 import Flashcard from "@/components/learn/interactive/Flashcard";
 import KnowledgeCheck from "@/components/learn/interactive/KnowledgeCheck";
 import TTSButton from "@/components/learn/interactive/TTSButton";
@@ -161,63 +161,20 @@ export default function Lesson1Interactive({ lesson, lessonProgress }: Lesson1In
           <div className="flex-1 min-w-0 ">
 
             {/* ─── HERO ─── */}
-            <section id="hero" className="mb-6 scroll-mt-32">
-              <Link href="/learn" onClick={(e) => { if (window.history.length > 1) { e.preventDefault(); window.history.back(); } }} className="inline-flex items-center gap-1 text-amber-600 hover:text-amber-800 text-sm mb-4 transition-colors">
-                <ArrowLeft className="w-4 h-4" /> Back to Learning Path
-              </Link>
-
-              <motion.div {...fadeUp}>
-                <div className="flex items-center gap-2 mb-2 flex-wrap">
-                  <GraduationCap className="w-5 h-5 text-amber-500" />
-                  <span className="text-xs font-bold text-amber-500 uppercase tracking-wider">Lesson {lesson.sequenceOrder}</span>
-                  <span className="text-xs text-amber-400">·</span>
-                  <span className="text-xs font-medium text-amber-600">Module 1: Foundations</span>
-                  {isCompleted && (
-                    <span className="ml-2 text-xs font-bold px-2 py-0.5 rounded-full bg-green-100 text-green-700 border border-green-200 flex items-center gap-1">
-                      <CheckCircle2 className="w-3 h-3" /> Completed
-                    </span>
-                  )}
-                  {isLocked && (
-                    <span className="ml-2 text-xs font-bold px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 border border-gray-200 flex items-center gap-1">
-                      <Lock className="w-3 h-3" /> Locked
-                    </span>
-                  )}
-                </div>
-
-                <h1 className="text-3xl sm:text-4xl font-bold text-amber-900 mb-3">{lesson.title}</h1>
-
-                <div className="flex items-center gap-4 flex-wrap">
-                  <ReadingTime text={allText} />
-                  <span className="text-amber-300">·</span>
-                  <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700">
-                    <Layers className="w-3.5 h-3.5" /> {content.sections?.length || 0} Sections
-                  </span>
-                  <span className="text-amber-200">·</span>
-                  <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-600">
-                    <Lightbulb className="w-3.5 h-3.5" /> {content.concepts.length} Concepts
-                  </span>
-                  <span className="text-amber-200">·</span>
-                  <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-600">
-                    <BrainCircuit className="w-3.5 h-3.5" /> {content.quiz.length} Questions
-                  </span>
-                </div>
-
-                {/* Progress bar */}
-                {hasSections && (
-                  <div className="mt-4 flex items-center gap-3">
-                    <div className="flex-1 h-2 bg-amber-100 rounded-full overflow-hidden max-w-[250px]">
-                      <motion.div
-                        className="h-full bg-gradient-to-r from-green-400 to-emerald-500 rounded-full"
-                        initial={{ width: 0 }}
-                        animate={{ width: `${sectionProgress}%` }}
-                        transition={{ duration: 0.6 }}
-                      />
-                    </div>
-                    <span className="text-xs text-amber-600 font-medium">{completedSections.size}/{content.sections?.length} viewed</span>
-                  </div>
-                )}
-              </motion.div>
-            </section>
+            <LessonHeader
+              title={lesson.title}
+              lessonNumber={lesson.sequenceOrder}
+              moduleNumber={lesson.module}
+              chapterNumber={lesson.chapter}
+              chapterTitle={lesson.chapter > 0 ? `What Jyotiṣa Is` : undefined}
+              isCompleted={isCompleted}
+              isLocked={isLocked}
+              allText={allText}
+              conceptCount={content.concepts.length}
+              quizCount={content.quiz.length}
+              bestScore={lessonProgress?.bestScore || 0}
+              attemptsCount={lessonProgress?.attemptsCount || 0}
+            />
 
             {/* ─── KEY TAKEAWAYS OVERVIEW ─── */}
             <section id="sec-overview" className="mb-6 scroll-mt-32">

--- a/src/components/learn/module1/chapter1/Lesson1Interactive.tsx
+++ b/src/components/learn/module1/chapter1/Lesson1Interactive.tsx
@@ -2,14 +2,14 @@
 import React, { useCallback, useMemo, useState } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { ArrowLeft, GraduationCap, CheckCircle2, Lock, ChevronRight, BookOpen, Layers, Sparkles, BrainCircuit, Eye, Lightbulb, Play, BookMarked, Clock, GitCompare, ScrollText } from "lucide-react";
+import { GraduationCap, CheckCircle2, Lock, ChevronRight, BookOpen, Layers, Sparkles, BrainCircuit, Eye, Lightbulb, Play, BookMarked, Clock, GitCompare, ScrollText } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { learnApi, type Lesson, type LessonProgressData } from "@/lib/api";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
 import { useReadingProgress } from "@/hooks/useReadingProgress";
 import ScrollProgress from "@/components/learn/interactive/ScrollProgress";
 import LessonSidebar from "@/components/learn/interactive/LessonSidebar";
-import ReadingTime from "@/components/learn/interactive/ReadingTime";
+import LessonHeader from "@/components/learn/interactive/LessonHeader";
 import TTSButton from "@/components/learn/interactive/TTSButton";
 import Flashcard from "@/components/learn/interactive/Flashcard";
 import KnowledgeCheck from "@/components/learn/interactive/KnowledgeCheck";
@@ -66,65 +66,58 @@ export default function Lesson1Interactive({ lesson, lessonProgress }: Props) {
     <>
       <ScrollProgress />
       <div className="mx-auto pb-20">
-        <div className="flex gap-8">
-          <LessonSidebar sections={buildSidebarSections(parsed)} activeSection={activeSection} completedSections={completedSections} onNavigate={scrollTo} progress={progress} className="w-64 shrink-0 sticky top-4 self-start h-fit" />
+        <div className="flex gap-6">
+          {/* Sidebar */}
+          <LessonSidebar sections={buildSidebarSections(parsed)} activeSection={activeSection} completedSections={completedSections} onNavigate={scrollTo} progress={progress} showProgress={false} className="w-64 shrink-0 sticky top-4 self-start h-fit" />
 
-          <div className="flex-1 min-w-0  space-y-6">
+          {/* Main column */}
+          <div className="flex-1 min-w-0 space-y-5">
+            {/* Sticky header inside main column */}
+            <div className="sticky top-0 z-30 bg-gradient-to-br from-amber-50/95 via-orange-50/95 to-yellow-50/95 backdrop-blur-md -mx-4 px-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8 py-1">
+              <LessonHeader
+                title={lesson.title}
+                lessonNumber={lesson.sequenceOrder}
+                moduleNumber={lesson.module}
+                chapterNumber={lesson.chapter}
+                chapterTitle="What Jyotiṣa Is"
+                isCompleted={isCompleted}
+                isLocked={isLocked}
+                allText={allText}
+                conceptCount={content.concepts.length}
+                quizCount={content.quiz.length}
+                bestScore={lessonProgress?.bestScore || 0}
+                attemptsCount={lessonProgress?.attemptsCount || 0}
+                progress={progress}
+              />
+            </div>
+            {/* Intro card */}
+            <motion.div {...fadeUp} className="mt-4 relative overflow-hidden bg-gradient-to-br from-white via-amber-50/30 to-orange-50/20 rounded-2xl border border-amber-200/60 shadow-sm p-5 sm:p-6">
+              {/* Decorative accent */}
+              <div className="absolute top-0 right-0 w-24 h-24 bg-amber-100/30 rounded-full blur-2xl -translate-y-1/2 translate-x-1/2" />
+              <div className="flex items-center gap-2 mb-4 relative">
+                <div className="w-7 h-7 rounded-lg bg-amber-100 flex items-center justify-center"><BookOpen className="w-3.5 h-3.5 text-amber-700" /></div>
+                <span className="text-sm font-semibold text-amber-800 uppercase tracking-wide">Introduction</span>
+                <span className="ml-auto"><TTSButton text={introHook} size="sm" label="Listen" /></span>
+              </div>
 
-            {/* ═══ HERO ═══ */}
-            <section id="hero" className="scroll-mt-32">
-              <Link href="/learn" onClick={(e) => { if (window.history.length > 1) { e.preventDefault(); window.history.back(); } }} className="inline-flex items-center gap-1 text-amber-600 hover:text-amber-800 text-sm mb-4 transition-colors">
-                <ArrowLeft className="w-4 h-4" /> Back to Learning Path
-              </Link>
-              <motion.div {...fadeUp}>
-                <div className="flex items-center gap-2 mb-2 flex-wrap">
-                  <GraduationCap className="w-5 h-5 text-amber-500" />
-                  <span className="text-xs font-bold text-amber-500 uppercase tracking-wider">Lesson {lesson.sequenceOrder}</span>
-                  <span className="text-xs text-amber-400">·</span>
-                  <span className="text-xs font-medium text-amber-600">Module 01 · Ch.1 — What Jyotiṣa Is</span>
-                  {isCompleted && <span className="ml-2 text-xs font-bold px-2 py-0.5 rounded-full bg-green-100 text-green-700 border border-green-200 flex items-center gap-1"><CheckCircle2 className="w-3 h-3" /> Completed</span>}
-                  {isLocked && <span className="ml-2 text-xs font-bold px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 border border-gray-200 flex items-center gap-1"><Lock className="w-3 h-3" /> Locked</span>}
-                </div>
-                <h1 className="text-3xl sm:text-4xl font-bold text-amber-900 mb-3">{lesson.title}</h1>
-                <div className="flex items-center gap-4 flex-wrap">
-                  <ReadingTime text={allText} />
-                  <span className="text-amber-300">·</span>
-                  <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700"><Layers className="w-3.5 h-3.5" /> 8 Sections</span>
-                  <span className="text-amber-200">·</span>
-                  <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-600"><Lightbulb className="w-3.5 h-3.5" /> {content.concepts.length} Concepts</span>
-                  <span className="text-amber-200">·</span>
-                  <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-600"><BrainCircuit className="w-3.5 h-3.5" /> {content.quiz.length} Questions</span>
-                </div>
-              </motion.div>
-              {/* Intro card */}
-              <motion.div {...fadeUp} className="mt-4 relative overflow-hidden bg-gradient-to-br from-white via-amber-50/30 to-orange-50/20 rounded-2xl border border-amber-200/60 shadow-sm p-5 sm:p-6">
-                {/* Decorative accent */}
-                <div className="absolute top-0 right-0 w-24 h-24 bg-amber-100/30 rounded-full blur-2xl -translate-y-1/2 translate-x-1/2" />
-                <div className="flex items-center gap-2 mb-4 relative">
-                  <div className="w-7 h-7 rounded-lg bg-amber-100 flex items-center justify-center"><BookOpen className="w-3.5 h-3.5 text-amber-700" /></div>
-                  <span className="text-sm font-semibold text-amber-800 uppercase tracking-wide">Introduction</span>
-                  <span className="ml-auto"><TTSButton text={introHook} size="sm" label="Listen" /></span>
-                </div>
+              {/* Key question - highlighted */}
+              <div className="relative mb-4 p-4 bg-amber-50/80 rounded-xl border border-amber-200/50">
+                <p className="text-amber-900 leading-relaxed text-[15px]">
+                  When you open a Vedic-astrology textbook and read <em>&ldquo;Jyotisa is the eye of the Veda&rdquo;</em>, what does that <strong>mean</strong>?
+                </p>
+              </div>
 
-                {/* Key question - highlighted */}
-                <div className="relative mb-4 p-4 bg-amber-50/80 rounded-xl border border-amber-200/50">
-                  <p className="text-amber-900 leading-relaxed text-[15px]">
-                    When you open a Vedic-astrology textbook and read <em>&ldquo;Jyotisa is the eye of the Veda&rdquo;</em>, what does that <strong>mean</strong>?
-                  </p>
+              {/* Answer - structured */}
+              <div className="relative space-y-3">
+                <p className="text-gray-700 leading-relaxed text-[15px]">
+                  The answer is structural: Jyotisa is <strong className="text-amber-800">one of six disciplines</strong> the Vedic tradition treats as essential infrastructure for the Veda itself.
+                </p>
+                <div className="flex items-center gap-3 p-3 bg-white rounded-xl border border-amber-100 shadow-sm">
+                  <div className="w-8 h-8 rounded-lg bg-amber-100 flex items-center justify-center shrink-0"><Sparkles className="w-4 h-4 text-amber-600" /></div>
+                  <p className="text-sm text-amber-900 font-medium">They are called <em>Vedangas</em> — <strong>limbs of the Veda</strong>. Today we place Jyotisa within its proper textual home.</p>
                 </div>
-
-                {/* Answer - structured */}
-                <div className="relative space-y-3">
-                  <p className="text-gray-700 leading-relaxed text-[15px]">
-                    The answer is structural: Jyotisa is <strong className="text-amber-800">one of six disciplines</strong> the Vedic tradition treats as essential infrastructure for the Veda itself.
-                  </p>
-                  <div className="flex items-center gap-3 p-3 bg-white rounded-xl border border-amber-100 shadow-sm">
-                    <div className="w-8 h-8 rounded-lg bg-amber-100 flex items-center justify-center shrink-0"><Sparkles className="w-4 h-4 text-amber-600" /></div>
-                    <p className="text-sm text-amber-900 font-medium">They are called <em>Vedangas</em> — <strong>limbs of the Veda</strong>. Today we place Jyotisa within its proper textual home.</p>
-                  </div>
-                </div>
-              </motion.div>
-            </section>
+              </div>
+            </motion.div>
 
             {/* ═══ WHAT YOU'LL LEARN ═══ */}
             <section id="sec-overview" className="scroll-mt-32">
@@ -133,10 +126,10 @@ export default function Lesson1Interactive({ lesson, lessonProgress }: Props) {
                 {lesson.learningOutcomes && lesson.learningOutcomes.length > 0 && (
                   <div className="mb-5">
                     <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wide mb-3">By the end of this lesson, you will be able to:</h3>
-                    <div className="space-y-2">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                       {lesson.learningOutcomes.map((o: string, i: number) => (
                         <div key={i} className="flex items-start gap-3 p-3 rounded-xl border border-gray-100 bg-gray-50/50 hover:bg-amber-50/50 hover:border-amber-200/50 transition-colors">
-                          <span className="w-6 h-6 rounded-full bg-amber-500 text-white flex items-center justify-center text-xs font-bold shrink-0 mt-0.5">{i+1}</span>
+                          <span className="w-6 h-6 rounded-full bg-amber-500 text-white flex items-center justify-center text-xs font-bold shrink-0 mt-0.5">{i + 1}</span>
                           <span className="text-sm text-gray-700 leading-relaxed">{o}</span>
                         </div>
                       ))}

--- a/src/components/learn/module1/chapter1/Lesson1Sections.tsx
+++ b/src/components/learn/module1/chapter1/Lesson1Sections.tsx
@@ -410,18 +410,23 @@ export function VsVedantaSection({ comparison }: { comparison: ParsedComparison 
 export function NonCoverageSection({ items }: { items: string[] }) {
   const [open, setOpen] = useState(false);
   return (
-    <motion.div {...fade} className="bg-gray-50 rounded-2xl border border-gray-200 overflow-hidden">
-      <button onClick={() => setOpen(!open)} className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-100/80 transition-colors">
+    <motion.div {...fade} className="bg-white rounded-2xl border border-amber-200/70 shadow-sm overflow-hidden">
+      <button onClick={() => setOpen(!open)} className="w-full flex items-center justify-between p-4 text-left hover:bg-amber-50/50 transition-colors">
         <div className="flex items-center gap-2.5">
-          <div className="w-7 h-7 rounded-lg bg-gray-200 flex items-center justify-center"><AlertTriangle className="w-3.5 h-3.5 text-gray-500" /></div>
-          <h2 className="text-sm font-bold text-gray-700">What This Lesson Does NOT Teach</h2>
+          <div className="w-8 h-8 rounded-lg bg-amber-100 flex items-center justify-center"><AlertTriangle className="w-4 h-4 text-amber-600" /></div>
+          <h2 className="text-base font-bold text-amber-900">What This Lesson Does NOT Teach</h2>
         </div>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform duration-300 ${open ? "rotate-180" : ""}`} />
+        <ChevronDown className={`w-4 h-4 text-amber-400 transition-transform duration-300 ${open ? "rotate-180" : ""}`} />
       </button>
       {open && (
-        <div className="px-4 pb-4 space-y-2 border-t border-gray-200 pt-3 animate-in fade-in slide-in-from-top-2 duration-300">
+        <div className="px-4 pb-4 space-y-3 border-t border-amber-100 pt-4 animate-in fade-in slide-in-from-top-2 duration-300">
           {items.map((item, i) => (
-            <p key={i} className="text-xs text-gray-600 flex gap-2 items-start"><span className="text-gray-300">✕</span>{item}</p>
+            <div key={i} className="flex gap-3 items-start p-3 rounded-xl bg-amber-50/40 border border-amber-100/60">
+              <span className="w-5 h-5 rounded-full bg-amber-200 flex items-center justify-center shrink-0 mt-0.5">
+                <span className="text-amber-700 text-xs font-bold">✕</span>
+              </span>
+              <p className="text-sm text-gray-700 leading-relaxed">{item}</p>
+            </div>
           ))}
         </div>
       )}
@@ -548,7 +553,7 @@ function MemoryCard({ item, index }: { item: string; index: number }) {
       className={`relative rounded-xl border p-3.5 transition-all duration-300 ${
         gotIt
           ? "bg-gradient-to-r from-emerald-50/80 to-green-50/40 border-emerald-300/60"
-          : `bg-gradient-to-r ${meta.lightColor}/80 to-white ${meta.borderColor}/50 hover:shadow-sm`
+          : "bg-white border-gray-200 hover:shadow-sm"
       }`}
     >
       {/* Horizontal layout: Icon | Content | Toggle */}
@@ -562,7 +567,7 @@ function MemoryCard({ item, index }: { item: string; index: number }) {
               {gotIt ? "Memorized" : meta.label}
             </span>
           </div>
-          <p className={`text-sm leading-relaxed ${gotIt ? "text-emerald-900/80" : "text-gray-800"}`} dangerouslySetInnerHTML={{ __html: formatted }} />
+          <p className={`text-sm leading-relaxed font-semibold ${gotIt ? "text-emerald-900/80" : "text-gray-800"}`} dangerouslySetInnerHTML={{ __html: formatted }} />
         </div>
         <button
           onClick={() => setGotIt(!gotIt)}
@@ -599,7 +604,7 @@ export function RememberSection({ items }: { items: string[] }) {
       </div>
 
       {/* Cards */}
-      <div className="space-y-3">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {items.map((item, i) => (
           <MemoryCard key={i} item={item} index={i} />
         ))}
@@ -811,32 +816,85 @@ export function SummarySection({ paragraphs, insights }: { paragraphs: string[];
 }
 
 // ─── §12 Citations — Further Reading ─────────────────────────
+const CITATION_META: Record<string, { label: string; icon: LucideIcon; color: string; bg: string; border: string; accent: string }> = {
+  primary:  { label: "Primary Classical Sources", icon: ScrollText, color: "text-amber-800", bg: "bg-amber-50", border: "border-amber-200", accent: "bg-amber-400" },
+  modern:   { label: "Modern Translations", icon: BookOpen, color: "text-sky-800", bg: "bg-sky-50", border: "border-sky-200", accent: "bg-sky-400" },
+  further:  { label: "Going Deeper (Optional)", icon: Star, color: "text-violet-800", bg: "bg-violet-50", border: "border-violet-200", accent: "bg-violet-400" },
+};
+
 export function CitationsSection({ citations }: { citations: ParsedCitations }) {
   const [open, setOpen] = useState(false);
+
   return (
-    <motion.div {...fade} className="bg-gray-50 rounded-2xl border border-gray-200 overflow-hidden">
-      <button onClick={() => setOpen(!open)} className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-100/80 transition-colors">
-        <div className="flex items-center gap-2.5">
-          <div className="w-7 h-7 rounded-lg bg-gray-200 flex items-center justify-center"><BookOpen className="w-3.5 h-3.5 text-gray-600" /></div>
-          <h2 className="text-sm font-bold text-gray-700">Citations &amp; Further Reading</h2>
+    <motion.div {...fade} className="bg-white rounded-2xl border border-amber-200/60 shadow-sm overflow-hidden">
+      {/* Header */}
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between p-4 text-left hover:bg-amber-50/40 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <div className="w-9 h-9 rounded-xl bg-amber-100 flex items-center justify-center">
+            <BookOpen className="w-4 h-4 text-amber-700" />
+          </div>
+          <div>
+            <h2 className="text-base font-bold text-amber-900">Citations &amp; Further Reading</h2>
+            <p className="text-xs text-gray-500">Primary sources, translations &amp; next lessons</p>
+          </div>
         </div>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform duration-300 ${open ? "rotate-180" : ""}`} />
+        <ChevronDown className={`w-5 h-5 text-amber-400 transition-transform duration-300 ${open ? "rotate-180" : ""}`} />
       </button>
+
       {open && (
-        <div className="px-4 pb-4 space-y-4 border-t border-gray-200 pt-3 animate-in fade-in slide-in-from-top-2 duration-300">
-          {(["primary", "modern", "further"] as const).map((key) => (
-            <div key={key}>
-              <p className="text-[10px] font-bold text-gray-500 uppercase tracking-wide mb-1.5">{key === "primary" ? "Primary Classical Sources" : key === "modern" ? "Modern Translations" : "Going Deeper (Optional)"}</p>
-              {citations[key].map((c, i) => (
-                <div key={i} className="flex gap-2 items-start mb-1.5"><span className="text-gray-300 text-xs mt-0.5">•</span><div><p className="text-xs text-gray-700 font-medium">{c.ref}</p>{c.note && <p className="text-[10px] text-gray-500">{c.note}</p>}</div></div>
-              ))}
-            </div>
-          ))}
+        <div className="px-4 pb-5 border-t border-amber-100 pt-4 space-y-5 animate-in fade-in slide-in-from-top-2 duration-300">
+          {/* Primary / Modern / Further */}
+          {(["primary", "modern", "further"] as const).map((key) => {
+            const meta = CITATION_META[key];
+            const Icon = meta.icon;
+            return (
+              <div key={key}>
+                <div className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg ${meta.bg} ${meta.border} border mb-2.5`}>
+                  <Icon className={`w-3.5 h-3.5 ${meta.color}`} />
+                  <span className={`text-[11px] font-bold uppercase tracking-wider ${meta.color}`}>{meta.label}</span>
+                </div>
+                <div className="space-y-2">
+                  {citations[key].map((c, i) => (
+                    <div
+                      key={i}
+                      className="relative pl-3 pr-3 py-2.5 rounded-xl bg-gray-50/60 border border-gray-100 hover:bg-gray-50 hover:border-gray-200 transition-colors"
+                    >
+                      <div className={`absolute left-0 top-3 bottom-3 w-1 rounded-full ${meta.accent}`} />
+                      <p className="text-sm font-semibold text-gray-800">{c.ref}</p>
+                      {c.note && <p className="text-xs text-gray-500 mt-0.5 leading-relaxed">{c.note}</p>}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+
+          {/* Cross-references */}
           {citations.crossRefs.length > 0 && (
-            <div><p className="text-[10px] font-bold text-amber-600 uppercase tracking-wide mb-1.5">Cross-references in this curriculum</p>
-              {citations.crossRefs.map((c, i) => (
-                <div key={i} className="flex gap-2 items-start mb-1.5"><span className="text-amber-300 text-xs mt-0.5">&rarr;</span><div><p className="text-xs text-amber-700 font-medium">{c.ref}</p>{c.note && <p className="text-[10px] text-gray-500">{c.note}</p>}</div></div>
-              ))}
+            <div>
+              <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-orange-50 border border-orange-200 mb-2.5">
+                <ArrowRight className="w-3.5 h-3.5 text-orange-700" />
+                <span className="text-[11px] font-bold uppercase tracking-wider text-orange-700">Cross-references in this curriculum</span>
+              </div>
+              <div className="grid grid-cols-1 gap-2">
+                {citations.crossRefs.map((c, i) => (
+                  <div
+                    key={i}
+                    className="flex items-start gap-3 p-3 rounded-xl bg-gradient-to-r from-orange-50/60 to-amber-50/40 border border-orange-200/50 hover:shadow-sm transition-shadow"
+                  >
+                    <div className="w-8 h-8 rounded-lg bg-white border border-orange-200 flex items-center justify-center shrink-0">
+                      <ArrowRight className="w-4 h-4 text-orange-500" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-bold text-orange-800">{c.ref}</p>
+                      {c.note && <p className="text-xs text-gray-600 mt-0.5 leading-relaxed">{c.note}</p>}
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/src/components/learn/module1/chapter1/VedangaWheel.tsx
+++ b/src/components/learn/module1/chapter1/VedangaWheel.tsx
@@ -138,7 +138,7 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
         <h3 className="text-xl font-extrabold text-amber-900 tracking-tight">
           The Six Vedangas — Limbs of the Veda
         </h3>
-        <p className="text-xs text-amber-600">
+        <p className="text-sm text-gray-600">
           Click any limb to explore its role, body metaphor &amp; key texts
         </p>
       </div>
@@ -147,12 +147,12 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
       <div className="flex items-center justify-center gap-3 mb-3 text-[10px] font-bold uppercase tracking-wider flex-wrap">
         <span className="flex items-center gap-1">
           <span className="w-2.5 h-2.5 rounded-full bg-amber-500" />
-          <span className="text-amber-700">
+          <span className="text-gray-800">
             Jyotisa = Eye (highlighted)
           </span>
         </span>
         <span className="text-gray-300">·</span>
-        <span className="text-gray-500">
+        <span className="text-gray-700">
           Each Vedanga = A body part of the Vedic Purusha
         </span>
       </div>
@@ -260,7 +260,7 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
               dominantBaseline="central"
               fontSize={13 * scale}
               fontWeight="900"
-              fill="#E65100"
+              fill="#333"
               letterSpacing="2"
             >
               VEDA
@@ -374,9 +374,9 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
                     x={pos.x}
                     y={labelY}
                     textAnchor="middle"
-                    fontSize={10 * scale}
+                    fontSize={14 * scale}
                     fontWeight="800"
-                    fill={v.color}
+                    fill="#1a1a1a"
                   >
                     {v.sanskrit}
                   </text>
@@ -386,8 +386,8 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
                       labelY + (isTopHalf ? -11 * scale : 11 * scale)
                     }
                     textAnchor="middle"
-                    fontSize={7.5 * scale}
-                    fill="#666"
+                    fontSize={11 * scale}
+                    fill="#333"
                   >
                     {v.english}
                   </text>
@@ -397,11 +397,10 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
                       labelY + (isTopHalf ? -22 * scale : 22 * scale)
                     }
                     textAnchor="middle"
-                    fontSize={7 * scale}
+                    fontSize={10 * scale}
                     fontWeight="600"
                     fontStyle="italic"
-                    fill={v.color}
-                    opacity={0.7}
+                    fill="#444"
                   >
                     {v.bodyPart}
                   </text>
@@ -440,8 +439,7 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
                     <h3
-                      className="text-lg font-bold"
-                      style={{ color: selected.color }}
+                      className="text-lg font-bold text-gray-900"
                     >
                       {selected.sanskrit}
                     </h3>
@@ -457,8 +455,7 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
                     </span>
                   </div>
                   <p
-                    className="text-sm font-medium mt-0.5"
-                    style={{ color: selected.color + "CC" }}
+                    className="text-sm font-medium mt-0.5 text-gray-700"
                   >
                     {selected.bodyPart}
                   </p>
@@ -475,8 +472,7 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
               {/* Function */}
               <div className="px-4 py-3 bg-white/40 border-y border-gray-100/50">
                 <div
-                  className="text-[10px] font-bold uppercase tracking-wider mb-1"
-                  style={{ color: selected.color }}
+                  className="text-xs font-bold uppercase tracking-wider mb-1 text-gray-600"
                 >
                   Primary Function
                 </div>
@@ -508,7 +504,7 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
               {selected.isHighlighted && (
                 <div className="px-4 pb-4">
                   <div className="p-3 rounded-xl bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-200">
-                    <div className="text-[10px] font-bold text-amber-700 uppercase tracking-wide mb-1 flex items-center gap-1">
+                    <div className="text-xs font-bold text-gray-700 uppercase tracking-wide mb-1 flex items-center gap-1">
                       <span>👁️</span> Why &ldquo;The Eye&rdquo;?
                     </div>
                     <p className="text-xs text-amber-800 leading-relaxed">
@@ -527,10 +523,10 @@ export default function VedangaWheel({ size = 620 }: VedangaWheelProps) {
               <div className="w-14 h-14 rounded-full bg-amber-100 flex items-center justify-center mb-3">
                 <span className="text-2xl">👁️</span>
               </div>
-              <p className="text-sm font-semibold text-amber-800">
+              <p className="text-base font-semibold text-gray-800">
                 Select a Vedanga
               </p>
-              <p className="text-xs text-amber-600 mt-1">
+              <p className="text-sm text-gray-600 mt-1">
                 Click any limb in the wheel to explore its role, body
                 metaphor, and key texts.
               </p>


### PR DESCRIPTION
…ion cards

- LessonHeader: new sticky hero card with breadcrumb badges, stat pills, ring progress, and border styling
- LessonSidebar: color-coded section icons, group headers with icons, removed progress from sidebar (moved to header), text wrap instead of truncate
- Flashcard: grid layout showing all cards at once, independent flip, 2-col horizontal answer items on back
- VedangaWheel: darker text colors, larger labels, improved contrast
- Lesson1Sections: grid layouts for What You'll Learn and Things to Remember, white card backgrounds, enhanced Citations section with colored groups
- NonCoverageSection: amber theme cards with improved styling
- page.tsx: removed top py-6 padding to eliminate header gap